### PR TITLE
Adjust media container width for improved responsiveness

### DIFF
--- a/site/plugins/themesforkirby/templates/post.php
+++ b/site/plugins/themesforkirby/templates/post.php
@@ -73,7 +73,7 @@
       </div>
 
       <?php if (($page->parent()->postMedia()->bool() || $page->parent()->postMedia()->isEmpty()) && $cover = $page->cover()->toFile()): ?>
-        <div class="<?php if ($page->parent()->postMediaBorder()->bool()): ?>border border-img <?php endif ?>max-width-lg rounded space-bottom-3x">
+        <div class="<?php if ($page->parent()->postMediaBorder()->bool()): ?>border border-img <?php endif ?>max-width-sm rounded space-bottom-3x">
           <img class="full-width" loading="lazy" src="<?= $cover->url() ?>"<?php if ($cover->extension() !== 'svg'): ?> srcset="<?= $cover->srcset() ?>"<?php endif ?> width="<?= $cover->width() ?>" height="<?= $cover->height() ?>" alt="<?= $page->title() ?>">
         </div>
       <?php endif ?>


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout of post media in the `post.php` template. It changes the maximum width of the media container from `max-width-lg` to `max-width-sm` for better alignment or visual consistency.

* [`site/plugins/themesforkirby/templates/post.php`](diffhunk://#diff-53904b723ff90becc57971b140f46eaaa6d27d163120ab74d89e973e3a843404L76-R76): Updated the `div` class to use `max-width-sm` instead of `max-width-lg` for the media container.