### PR TITLE
Add UniBE group with material card fieldset to blocks configuration

### DIFF
--- a/site/plugins/themesforkirby/blueprints/fields/blocks.yml
+++ b/site/plugins/themesforkirby/blueprints/fields/blocks.yml
@@ -12,6 +12,11 @@ fields:
           text: blocks/text
           button: blocks/button
           image: blocks/image
+      unibe:
+        label: UniBE
+        type: group
+        fieldsets:
+          materialcard: blocks/material-card
       text:
         label: Text
         type: group


### PR DESCRIPTION
This pull request adds a new `unibe` field group to the `blocks.yml` blueprint in the `themesforkirby` plugin. This change introduces support for a new `material-card` block type under the `unibe` group.

### New field group addition:

* [`site/plugins/themesforkirby/blueprints/fields/blocks.yml`](diffhunk://#diff-db9ff286d9be297438e4eccd38dc0b543e4eb4315cd32f2b1751d51e36728bb7R15-R19): Added a new `unibe` field group with the label "UniBE" and a `materialcard` block type (`blocks/material-card`).