### PR TITLE
Add UniBE group with material card fieldset to layout configuration

### DIFF
--- a/site/plugins/themesforkirby/blueprints/fields/layout.yml
+++ b/site/plugins/themesforkirby/blueprints/fields/layout.yml
@@ -19,6 +19,11 @@ fields:
           text: blocks/text
           button: blocks/button
           image: blocks/image
+      unibe:
+        label: UniBE
+        type: group
+        fieldsets:
+          materialcard: blocks/material-card
       text:
         label: Text
         type: group


### PR DESCRIPTION
This pull request introduces a new `unibe` field group to the `layout.yml` blueprint, enhancing the organization and modularity of the layout fields.

### Changes to layout fields:

* [`site/plugins/themesforkirby/blueprints/fields/layout.yml`](diffhunk://#diff-91c2f16b06ad8cc2bde45b87b506ba0e39f192fcc9a9742ada0019e5ab7119a6R22-R26): Added a new `unibe` field group with the label "UniBE" and a `materialcard` fieldset (`blocks/material-card`). This change improves the structure and customization options for layout fields.